### PR TITLE
Feature/hide leading 1 for offset positionalvariants 17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@bcgsc-pori/graphkb-parser",
-      "version": "1.1.3",
+      "version": "2.0.0",
       "license": "GPL-3.0",
       "dependencies": {
         "json-cycle": "^1.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16248,9 +16248,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mixin-deep": {
@@ -31264,9 +31264,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mixin-deep": {

--- a/src/position.ts
+++ b/src/position.ts
@@ -189,10 +189,10 @@ const convertPositionToString = (position) => {
         }
         return result;
     } if (['c', 'r', 'n'].includes(position.prefix)) {
-        let offset = '';
-        let pos = position.pos
-            ? String(position.pos)
-            : '?'
+        let offset = '',
+            pos = position.pos
+                ? String(position.pos)
+                : '?';
 
         if (position.offset === null) {
             offset = '?';
@@ -200,7 +200,7 @@ const convertPositionToString = (position) => {
             if (position.offset > 0) {
                 offset = '+';
             } else if (position.offset < 0 && position.pos === 1) {
-                pos = ''
+                pos = '';
             }
             offset = `${offset}${position.offset}`;
         }

--- a/src/position.ts
+++ b/src/position.ts
@@ -190,16 +190,21 @@ const convertPositionToString = (position) => {
         return result;
     } if (['c', 'r', 'n'].includes(position.prefix)) {
         let offset = '';
+        let pos = position.pos
+            ? String(position.pos)
+            : '?'
 
         if (position.offset === null) {
             offset = '?';
         } else if (position.offset) {
             if (position.offset > 0) {
                 offset = '+';
+            } else if (position.offset < 0 && position.pos === 1) {
+                pos = ''
             }
             offset = `${offset}${position.offset}`;
         }
-        return `${position.pos || '?'}${offset}`;
+        return `${pos}${offset}`;
     } if (position.prefix === 'p') {
         return `${position.refAA || '?'}${position.pos || '?'}`;
     }


### PR DESCRIPTION
Related to issue https://github.com/bcgsc/pori_graphkb_parser/issues/17
Following comment https://github.com/bcgsc/pori_graphkb_parser/issues/17#issuecomment-1235996399 about 2 possible ways to fix the issue.

This PR updates the convertPositionToString() function, which is used to generate the break1Repr and break2Repr properties of PositionalVariant.

That other PR follow a different (maybe better?) approch: https://github.com/bcgsc/pori_graphkb_parser/pull/19