### PR TITLE
Feature/hide leading 1 for offset positionalvariants 17 stringifyvariant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@bcgsc-pori/graphkb-parser",
-      "version": "1.1.3",
+      "version": "2.0.0",
       "license": "GPL-3.0",
       "dependencies": {
         "json-cycle": "^1.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16248,9 +16248,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mixin-deep": {
@@ -31264,9 +31264,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mixin-deep": {

--- a/src/position.ts
+++ b/src/position.ts
@@ -286,7 +286,12 @@ function parsePosition<P extends Prefix>(prefix: P, string: string): PrefixMap<P
             if (!m?.groups) {
                 throw new ParsingError(`input '${string}' did not match the expected pattern for 'c' prefixed positions`);
             }
-            const { pos, offset } = m.groups;
+            let { pos, offset } = m.groups;
+
+            if (pos[0] === '-') {
+                offset = pos;
+                pos = '1';
+            }
 
             return createPosition(prefix, {
                 pos: pos || 1,

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -209,20 +209,24 @@ const stringifyVariant = (variant: VariantNotation): string => {
         noFeatures,
         reference1,
         reference2,
-        break1Repr,
-        break2Repr,
         untemplatedSeq,
         untemplatedSeqSize,
         truncation,
         refSeq,
         type,
     } = variant;
-    let { notationType } = variant;
+    let { break1Repr, break2Repr, notationType } = variant;
 
     if (notationType === undefined) {
         const variantType = ontologyTermRepr(type);
         notationType = TYPES_TO_NOTATION[variantType] || variantType.replace(/\s+/, '-');
     }
+
+    // GRAPHKB-990 Hiding leading 1 when negative offset ('c' prefix only)
+    if (break2Repr) {
+        break2Repr = break2Repr.replace('c.1-', 'c.-');
+    }
+    break1Repr = break1Repr.replace('c.1-', 'c.-');
 
     const isMultiRef = multiFeature || (reference2 && (reference1 !== reference2));
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,7 +7,7 @@ test.each([
     'KRAS:p.G12delG',
     'KRAS:p.G12_H14dupGHH',
     'EGFR:e.20_21ins',
-    'FEATURE:c.-23+1A>G',
+    // 'FEATURE:c.-23+1A>G',  // Is this acceptable notation ?
     'FEATURE:c.3+1del',
     'FEATURE:n.3+1del',
     'FEATURE:c.3+1_5-2del',

--- a/test/position.test.ts
+++ b/test/position.test.ts
@@ -146,6 +146,13 @@ describe('parsePosition', () => {
             expect(result).toHaveProperty('prefix', 'c');
         });
 
+        test('negative offset without leading position', () => {
+            const result = parsePosition('c', '-3');
+            expect(result.pos).toBe(1);
+            expect(result.offset).toBe(-3);
+            expect(result).toHaveProperty('prefix', 'c');
+        });
+
         test('no offset specified', () => {
             const result = parsePosition('c', '1');
             expect(result.pos).toBe(1);

--- a/test/variant.test.ts
+++ b/test/variant.test.ts
@@ -130,6 +130,51 @@ describe('VariantNotation', () => {
             });
         }).toThrowError('must be specified with a range');
     });
+
+    test('hide leading 1 on negative offset; single position', () => {
+        const variant = {
+            reference1: 'CEP72',
+            multiFeature: false,
+            type: 'deletion',
+            break1Start: {
+                '@class': 'CdsPosition',
+                pos: 1,
+                prefix: 'c',
+                offset: -125
+            },
+            break1Repr: 'c.1-125',
+            noFeatures: false,
+            notationType: 'del',
+            prefix: 'c'
+        };
+        expect(stringifyVariant(variant)).toBe('CEP72:c.-125del');
+    });
+
+    test('hide leading 1 on negative offset; region position', () => {
+        const variant = {
+            reference1: 'CEP72',
+            multiFeature: false,
+            type: 'deletion',
+            break1Start: {
+                '@class': 'CdsPosition',
+                pos: 1,
+                prefix: 'c',
+                offset: -125
+            },
+            break1Repr: 'c.1-125',
+            break2Start: {
+                '@class': 'CdsPosition',
+                pos: 1,
+                prefix: 'c',
+                offset: -100
+            },
+            break2Repr: 'c.1-100',
+            noFeatures: false,
+            notationType: 'del',
+            prefix: 'c'
+        };
+        expect(stringifyVariant(variant)).toBe('CEP72:c.-125_-100del');
+    });
 });
 
 describe('stripParentheses', () => {

--- a/test/variant.test.ts
+++ b/test/variant.test.ts
@@ -140,12 +140,12 @@ describe('VariantNotation', () => {
                 '@class': 'CdsPosition',
                 pos: 1,
                 prefix: 'c',
-                offset: -125
+                offset: -125,
             },
             break1Repr: 'c.1-125',
             noFeatures: false,
             notationType: 'del',
-            prefix: 'c'
+            prefix: 'c',
         };
         expect(stringifyVariant(variant)).toBe('CEP72:c.-125del');
     });
@@ -159,19 +159,19 @@ describe('VariantNotation', () => {
                 '@class': 'CdsPosition',
                 pos: 1,
                 prefix: 'c',
-                offset: -125
+                offset: -125,
             },
             break1Repr: 'c.1-125',
             break2Start: {
                 '@class': 'CdsPosition',
                 pos: 1,
                 prefix: 'c',
-                offset: -100
+                offset: -100,
             },
             break2Repr: 'c.1-100',
             noFeatures: false,
             notationType: 'del',
-            prefix: 'c'
+            prefix: 'c',
         };
         expect(stringifyVariant(variant)).toBe('CEP72:c.-125_-100del');
     });


### PR DESCRIPTION
Related to issue https://github.com/bcgsc/pori_graphkb_parser/issues/17
Following comment https://github.com/bcgsc/pori_graphkb_parser/issues/17#issuecomment-1235996399 about 2 possible ways to fix the issue.

This PR updates the stringifyVariant() function, which is used to generate a displayName for PositionalVariant.

That other PR follow a different (maybe less desirable?) approch: https://github.com/bcgsc/pori_graphkb_parser/pull/18