### PR TITLE
Bugfix/kbdev 1346 parser update

### DIFF
--- a/data/variants.ts
+++ b/data/variants.ts
@@ -31,6 +31,18 @@ const standardVariants = {
         type: NOTATION_TO_TYPES.mis,
         untemplatedSeq: 'D',
     },
+    'TP53:c.*123del': {
+        break1Start: {
+            '@class': 'CdsPosition',
+            pos: 0,
+            offset: 123,
+            prefix: 'c',
+        },
+        break1Repr: 'c.*123',
+        prefix: 'c',
+        reference1: 'TP53',
+        type: NOTATION_TO_TYPES.del,
+    },
 };
 
 // Actual fusion variant with legacy notation (KBDEV-974)

--- a/src/continuous.ts
+++ b/src/continuous.ts
@@ -105,7 +105,7 @@ const extractPositions = (
 
     const pattern = PATTERNS[prefix] || /(?<pos>\d+)/;
     const match = new RegExp(`^(${pattern.source})`, 'i').exec(string);
-    
+
     if (!match) {
         throw new ParsingError('Failed to parse the initial position');
     }

--- a/src/continuous.ts
+++ b/src/continuous.ts
@@ -106,6 +106,7 @@ const extractPositions = (
     const pattern = PATTERNS[prefix] || /(?<pos>\d+)/;
     const match = new RegExp(`^(${pattern.source})`, 'i').exec(string);
 
+    // TODO: Inspect pattern above since it seems this will never throw.
     if (!match) {
         throw new ParsingError('Failed to parse the initial position');
     }
@@ -125,7 +126,21 @@ const extractPositions = (
  *
  * @example
  * > parseContinuous('p.G12D')
- * {type: 'substitution', prefix: 'p', break1Start: {'@class': 'ProteinPosition', pos: 12, refAA: 'G'}, untemplatedSeq: 'D'}
+ * {
+ *      "break1End": undefined,
+ *      "break1Start": {
+ *          "@class": "ProteinPosition", "longRefAA": null, "pos": 12, "prefix": "p", "refAA": "G",
+ *      },
+ *      "break2End": undefined,
+ *      "break2Start": undefined,
+ *      "notationType": ">",
+ *      "prefix": "p",
+ *      "refSeq": "G",
+ *      "truncation": undefined,
+ *      "type": "missense mutation",
+ *      "untemplatedSeq": "D",
+ *      "untemplatedSeqSize": undefined,
+ * }
  */
 const parseContinuous = (inputString) => {
     let string = inputString.slice(0);
@@ -136,7 +151,6 @@ const parseContinuous = (inputString) => {
 
     const prefix = getPrefix(string);
     string = string.slice(prefix.length + 1);
-    // get the first position
     let break1Start,
         break1End,
         break2Start,
@@ -147,6 +161,12 @@ const parseContinuous = (inputString) => {
         truncation,
         notationType; // type parsed
 
+    // Remove pattern for protein's predicted consequence
+    if (prefix === 'p' && string.startsWith('(') && string.endsWith(')')) {
+        string = string.slice(1, -1);
+    }
+
+    // extract the first position
     try {
         const parsedPosition = extractPositions(prefix, string);
         break1Start = parsedPosition.start;
@@ -157,8 +177,8 @@ const parseContinuous = (inputString) => {
         throw err;
     }
 
+    // if expect a range, then extract more positions
     if (string.startsWith('_')) {
-        // expect a range. Extract more positions
         string = string.slice(1);
 
         try {
@@ -407,4 +427,9 @@ const parseContinuous = (inputString) => {
     };
 };
 
-export { parseContinuous, getPrefix };
+export {
+    convert3to1,
+    extractPositions,
+    getPrefix,
+    parseContinuous,
+};

--- a/src/continuous.ts
+++ b/src/continuous.ts
@@ -56,6 +56,10 @@ const convert3to1 = (notation: string): string => {
         // = does not have a 3-letter AA equivalent
         return '=';
     }
+    if (notation === AA_CODES.ter) {
+        // * as termination codon
+        return AA_CODES.ter;
+    }
     if (notation.length % 3 !== 0) {
         throw new ParsingError(`Cannot convert to single letter AA notation. The input (${notation}) is not in 3-letter form`);
     }
@@ -98,9 +102,10 @@ const extractPositions = (
             end: parsePosition(prefix, string.slice(string.indexOf('_') + 1, string.indexOf(')'))),
         };
     }
+
     const pattern = PATTERNS[prefix] || /(?<pos>\d+)/;
     const match = new RegExp(`^(${pattern.source})`, 'i').exec(string);
-
+    
     if (!match) {
         throw new ParsingError('Failed to parse the initial position');
     }

--- a/src/position.ts
+++ b/src/position.ts
@@ -300,7 +300,9 @@ function parsePosition<P extends Prefix>(prefix: P, string: string): PrefixMap<P
             }
 
             return createPosition(prefix, {
-                pos: pos || 1,
+                pos: pos === undefined || pos === '' // pos 0 is allowed for 3'UTR variants
+                    ? 1 // undefined pos means 1, e.g. c.-2384C>T,
+                    : pos,
                 offset: offset === undefined
                     ? 0
                     : offset,

--- a/src/position.ts
+++ b/src/position.ts
@@ -293,25 +293,22 @@ function parsePosition<P extends Prefix>(prefix: P, string: string): PrefixMap<P
             }
             let { ter, pos, offset } = m.groups;
 
-            // KBDEV-1346; assuming c.1-123... means c.-123... for backward compatibility
-            if (parseInt(pos, 10) === 1 && parseInt(offset, 10) < 0) {
-                pos = offset;
-                offset = '0';
-            }
             // KBDEV-1346; allow pos === 0 as an alias for termination codon position
             if (ter) {
                 offset = pos;
                 pos = '0';
             }
 
-            return createPosition(prefix, {
-                pos: pos === undefined || pos === '' // pos 0 is allowed for 3'UTR variants
-                    ? 1 // undefined pos means 1, e.g. c.-2384C>T,
-                    : pos,
-                offset: offset === undefined
-                    ? 0
-                    : offset,
-            });
+            // Fixing pos vs offset parsing
+            if (pos === undefined || pos === '') { // pos 0 is allowed for 3'UTR variants
+                pos = offset || '1'; // e.g. c.-2384C>T
+                offset = '0';
+            }
+            if (offset === undefined) {
+                offset = '0';
+            }
+
+            return createPosition(prefix, { pos, offset });
         } if (prefix === 'g' || prefix === 'e' || prefix === 'i') {
             // basic pos
             return createPosition(prefix, { pos: string });

--- a/src/position.ts
+++ b/src/position.ts
@@ -4,7 +4,7 @@ import {
     AA_PATTERN, AA_CODES, PREFIX_CLASS, Prefix,
 } from './constants';
 
-const CDSLIKE_PATT = /(?<pos>-?(\d+|\?))?(?<offset>[-+](\d+|\?))?/;
+const CDSLIKE_PATT = /(?<ter>\*)?(?<pos>-?(\d+|\?))?(?<offset>[-+](\d+|\?))?/;
 const CLASS_FIELD = '@class';
 const PATTERNS = {
     y: /(?<arm>[pq])((?<majorBand>\d+|\?)(\.(?<minorBand>\d+|\?))?)?/,
@@ -177,6 +177,11 @@ function createPosition<P extends Prefix>(prefix: P, position: any): PrefixMap<P
 }
 
 const convertPositionToString = (position) => {
+    // KBDEV-1346; pos === 0 as an alias for termination codon position
+    const pos = position.pos === 0
+        ? AA_CODES.ter
+        : position.pos;
+
     if (position.prefix === 'y') {
         let result = `${position.arm}`;
 
@@ -194,16 +199,16 @@ const convertPositionToString = (position) => {
         if (position.offset === null) {
             offset = '?';
         } else if (position.offset) {
-            if (position.offset > 0) {
+            if (position.offset > 0 && pos !== AA_CODES.ter) {
                 offset = '+';
             }
             offset = `${offset}${position.offset}`;
         }
-        return `${position.pos || '?'}${offset}`;
+        return `${pos || '?'}${offset}`;
     } if (position.prefix === 'p') {
-        return `${position.refAA || '?'}${position.pos || '?'}`;
+        return `${position.refAA || '?'}${pos || '?'}`;
     }
-    return `${position.pos || '?'}`;
+    return `${pos || '?'}`;
 };
 
 /**
@@ -286,7 +291,13 @@ function parsePosition<P extends Prefix>(prefix: P, string: string): PrefixMap<P
             if (!m?.groups) {
                 throw new ParsingError(`input '${string}' did not match the expected pattern for 'c' prefixed positions`);
             }
-            const { pos, offset } = m.groups;
+            let { ter, pos, offset } = m.groups;
+
+            // KBDEV-1346; allow pos === 0 as an alias for termination codon position
+            if (ter) {
+                offset = pos;
+                pos = '0';
+            }
 
             return createPosition(prefix, {
                 pos: pos || 1,

--- a/src/position.ts
+++ b/src/position.ts
@@ -293,6 +293,11 @@ function parsePosition<P extends Prefix>(prefix: P, string: string): PrefixMap<P
             }
             let { ter, pos, offset } = m.groups;
 
+            // KBDEV-1346; assuming c.1-123... means c.-123... for backward compatibility
+            if (parseInt(pos, 10) === 1 && parseInt(offset, 10) < 0) {
+                pos = offset;
+                offset = '0';
+            }
             // KBDEV-1346; allow pos === 0 as an alias for termination codon position
             if (ter) {
                 offset = pos;

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -744,5 +744,9 @@ const parseVariant = (string, requireFeatures = true) => {
 };
 
 export {
-    parseVariant, jsonifyVariant, stringifyVariant, stripParentheses, createVariantNotation,
+    createVariantNotation,
+    jsonifyVariant,
+    parseVariant,
+    stringifyVariant,
+    stripParentheses,
 };

--- a/test/continuous.test.ts
+++ b/test/continuous.test.ts
@@ -1,0 +1,245 @@
+import { AA_CODES } from '../src/constants';
+import {
+    convert3to1,
+    extractPositions,
+    getPrefix,
+    parseContinuous,
+} from '../src/continuous';
+import { ParsingError, InputValidationError } from '../src/error';
+
+describe('convert3to1', () => {
+    test.each([
+        [AA_CODES.ter, AA_CODES.ter],
+        ['=', '='],
+        ['abc', ''],
+        ['trp', 'w'],
+        ['Trp', 'w'],
+        ['ArgLysLeu', 'rkl'],
+    ])('convert %s to %s', (string, expected) => {
+        expect(convert3to1(string)).toBe(expected);
+    });
+
+    test('throw ParsingError on length not multiple of 3', () => {
+        expect(() => convert3to1('abcd')).toThrow(ParsingError);
+    });
+});
+
+describe('getPrefix', () => {
+    test.each([
+        ['g.', 'g'],
+        ['g.123', 'g'],
+        ['y.123', 'y'],
+        ['c.123', 'c'],
+        ['r.123', 'r'],
+        ['i.123', 'i'],
+        ['e.123', 'e'],
+        ['p.123', 'p'],
+        ['n.123', 'n'],
+    ])('convert %s to %s', (string, expected) => {
+        expect(getPrefix(string)).toBe(expected);
+    });
+
+    test.each([
+        ['z', 'is not an accepted prefix'],
+        ['g', 'is missing seperator'],
+        ['g123', 'is missing seperator'],
+    ])('throw ParsingError on %s because %s', (string, _) => {
+        expect(() => getPrefix(string)).toThrow(ParsingError);
+    });
+});
+
+describe('extractPosition', () => {
+    test.each([
+        ['c', '1-2384C>T', { // TODO: needs to be fixed to '-2384C>T'
+            input: '1-2384',
+            start: {
+                '@class': 'CdsPosition', offset: -2384, pos: 1, prefix: 'c',
+            },
+        }],
+        ['p', 'G12D', {
+            input: 'G12',
+            start: {'@class': 'ProteinPosition', longRefAA: null, pos: 12, prefix: 'p', refAA: 'G'},
+        }],
+        // extract 1st position only
+        ['c', '123_456del', {
+            input: '123',
+            start: {'@class': 'CdsPosition', offset: 0, pos: 123, prefix: 'c'},
+        }],
+        ['c', '(123_456)_(567_890)del', {
+            input: '(123_456)',
+            start: {'@class': 'CdsPosition', offset: 0, pos: 123, prefix: 'c'},
+            end: {'@class': 'CdsPosition', offset: 0, pos: 456, prefix: 'c'},
+        }],
+    ])('extracting positions for %s.%s', (prefix, string, expected) => {
+        expect(extractPositions(prefix, string)).toEqual(expected);
+    });
+
+    test.each([
+        ['c', '(123_456del', 'is missing closing parenthesis'],
+        ['c', '(123)del', 'is missing end position'],
+        // [ 'c', 'del', 'no position'],  // TODO: to be addressed
+    ])('throw ParsingError on %s.%s because %s', (prefix, string, _) => {
+        expect(() => extractPositions(prefix, string)).toThrow(ParsingError);
+    });
+});
+
+describe('parseContinuous', () => {
+    test.each([
+        ['c.del', { // pos 1 assumed by default
+            break1Start: {
+                '@class': 'CdsPosition', offset: 0, pos: 1, prefix: 'c',
+            },
+            break1End: undefined,
+            break2Start: undefined,
+            break2End: undefined,
+            notationType: 'del',
+            prefix: 'c',
+            refSeq: undefined,
+            truncation: undefined,
+            type: 'deletion',
+            untemplatedSeq: undefined,
+            untemplatedSeqSize: undefined,
+        }],
+        ['p.G12D', {
+            break1End: undefined,
+            break1Start: {
+                '@class': 'ProteinPosition', longRefAA: null, pos: 12, prefix: 'p', refAA: 'G',
+            },
+            break2End: undefined,
+            break2Start: undefined,
+            notationType: '>',
+            prefix: 'p',
+            refSeq: 'G',
+            truncation: undefined,
+            type: 'missense mutation',
+            untemplatedSeq: 'D',
+            untemplatedSeqSize: undefined,
+        }],
+        ['c.123_456del', {
+            break1Start: {
+                '@class': 'CdsPosition', offset: 0, pos: 123, prefix: 'c', 
+            },
+            break1End: undefined,
+            break2Start: {
+                '@class': 'CdsPosition', offset: 0, pos: 456, prefix: 'c',
+            },
+            break2End: undefined,
+            notationType: 'del',
+            prefix: 'c',
+            refSeq: undefined,
+            truncation: undefined,
+            type: 'deletion',
+            untemplatedSeq: undefined,
+            untemplatedSeqSize: undefined,
+        }],
+        ['c.(123_456)_(567_890)del', {
+            break1Start: {
+                '@class': 'CdsPosition', offset: 0, pos: 123, prefix: 'c',
+            },
+            break1End: {
+                '@class': 'CdsPosition', offset: 0, pos: 456, prefix: 'c',
+            },
+            break2Start: {
+                '@class': 'CdsPosition', offset: 0, pos: 567, prefix: 'c',
+            },
+            break2End: {
+                '@class': 'CdsPosition', offset: 0, pos: 890, prefix: 'c',
+            },
+            notationType: 'del',
+            prefix: 'c',
+            refSeq: undefined,
+            truncation: undefined,
+            type: 'deletion',
+            untemplatedSeq: undefined,
+            untemplatedSeqSize: undefined,
+        }],
+        ['p.(123_456)_(567_890)del', {
+            break1Start: {
+                '@class': 'ProteinPosition', pos: 123, prefix: 'p', longRefAA: null, refAA: undefined,
+            },
+            break1End: {
+                '@class': 'ProteinPosition', pos: 456, prefix: 'p', longRefAA: null, refAA: undefined,
+            },
+            break2Start: {
+                '@class': 'ProteinPosition', pos: 567, prefix: 'p', longRefAA: null, refAA: undefined,
+            },
+            break2End: {
+                '@class': 'ProteinPosition', pos: 890, prefix: 'p', longRefAA: null, refAA: undefined,
+            },
+            notationType: 'del',
+            prefix: 'p',
+            refSeq: undefined,
+            truncation: undefined,
+            type: 'deletion',
+            untemplatedSeq: undefined,
+            untemplatedSeqSize: undefined,
+        }],
+        ['p.(L797P)', { // protein predicted consequences
+            break1Start: {
+                '@class': 'ProteinPosition', pos: 797, prefix: 'p', longRefAA: null, refAA: 'L',
+            },
+            break1End: undefined,
+            break2Start: undefined,
+            break2End: undefined,
+            notationType: '>',
+            prefix: 'p',
+            refSeq: 'L',
+            truncation: undefined,
+            type: 'missense mutation',
+            untemplatedSeq: 'P',
+            untemplatedSeqSize: undefined,
+        }],
+        ['p.((123_456)_(567_890)del)', {
+            break1Start: {
+                '@class': 'ProteinPosition', pos: 123, prefix: 'p', longRefAA: null, refAA: undefined,
+            },
+            break1End: {
+                '@class': 'ProteinPosition', pos: 456, prefix: 'p', longRefAA: null, refAA: undefined,
+            },
+            break2Start: {
+                '@class': 'ProteinPosition', pos: 567, prefix: 'p', longRefAA: null, refAA: undefined,
+            },
+            break2End: {
+                '@class': 'ProteinPosition', pos: 890, prefix: 'p', longRefAA: null, refAA: undefined,
+            },
+            notationType: 'del',
+            prefix: 'p',
+            refSeq: undefined,
+            truncation: undefined,
+            type: 'deletion',
+            untemplatedSeq: undefined,
+            untemplatedSeqSize: undefined,
+        }],
+    ])('parsing %s', (inputString, expected) => {
+        expect(parseContinuous(inputString)).toEqual(expected);
+    });
+
+    test.each([
+        ['p.del', 'error on extracting 1st position'],
+        ['p.123_del', 'expecting 2nd position but there is none'],
+    ])('throw Error on %s because %s', (inputString, _) => {
+        expect(() => parseContinuous(inputString)).toThrow(Error);
+    });
+
+    test.each([
+        ['p.', 'length is too short'],
+        ['g.A123C', 'all substitutions except protein must use the \'>\' symbol'],
+        ['p.123w>a', 'the \'>\' symbol should not be used for protein substitutions'],
+        ['e.1a>b', 'substitutions not allowed with exonic notation'],
+        ['c.123fs', 'framechift only with protein notation'],
+        ['p.W123*fs*2', 'invalidd framechift'],
+        ['p.A123_B23Cfs*', 'frameshifts cannot span a range'],
+        ['c.123indelCC', 'unsupported indel (in lieu of delins) notation type'],
+        ['g.123T>A^B', 'cannot use ^ as untemplated'],
+        ['y.q1_q2dupA', 'cannot define reference sequence when using \'y\' prefix'],
+        ['y.p1_p2insA', 'cannot define untemplated sequence when using \'y\' prefix'],
+    ])('throw ParsingError on %s because %s', (inputString, _) => {
+        expect(() => parseContinuous(inputString)).toThrow(ParsingError);
+    });
+
+    test.each([
+        ['p.A123Bfs*A', 'truncation must be a number'],
+    ])('throw InputValidationError on %s because %s', (inputString, _) => {
+        expect(() => parseContinuous(inputString)).toThrow(InputValidationError);
+    });
+});

--- a/test/continuous.test.ts
+++ b/test/continuous.test.ts
@@ -50,12 +50,6 @@ describe('getPrefix', () => {
 
 describe('extractPosition', () => {
     test.each([
-        ['c', '1-2384C>T', { // TODO: needs to be fixed to '-2384C>T'
-            input: '1-2384',
-            start: {
-                '@class': 'CdsPosition', offset: -2384, pos: 1, prefix: 'c',
-            },
-        }],
         ['p', 'G12D', {
             input: 'G12',
             start: {
@@ -77,6 +71,19 @@ describe('extractPosition', () => {
             },
             end: {
                 '@class': 'CdsPosition', offset: 0, pos: 456, prefix: 'c',
+            },
+        }],
+        // KBDEV-1346
+        ['c', '1-2384C>T', {
+            input: '1-2384',
+            start: {
+                '@class': 'CdsPosition', offset: 0, pos: -2384, prefix: 'c',
+            },
+        }],
+        ['c', '-2384C>T', {
+            input: '-2384',
+            start: {
+                '@class': 'CdsPosition', offset: 0, pos: -2384, prefix: 'c',
             },
         }],
     ])('extracting positions for %s.%s', (prefix, string, expected) => {

--- a/test/continuous.test.ts
+++ b/test/continuous.test.ts
@@ -77,7 +77,7 @@ describe('extractPosition', () => {
         ['c', '1-2384C>T', {
             input: '1-2384',
             start: {
-                '@class': 'CdsPosition', offset: 0, pos: -2384, prefix: 'c',
+                '@class': 'CdsPosition', offset: -2384, pos: 1, prefix: 'c',
             },
         }],
         ['c', '-2384C>T', {

--- a/test/continuous.test.ts
+++ b/test/continuous.test.ts
@@ -58,17 +58,26 @@ describe('extractPosition', () => {
         }],
         ['p', 'G12D', {
             input: 'G12',
-            start: {'@class': 'ProteinPosition', longRefAA: null, pos: 12, prefix: 'p', refAA: 'G'},
+            start: {
+                '@class': 'ProteinPosition', longRefAA: null, pos: 12, prefix: 'p', refAA: 'G',
+            },
+
         }],
         // extract 1st position only
         ['c', '123_456del', {
             input: '123',
-            start: {'@class': 'CdsPosition', offset: 0, pos: 123, prefix: 'c'},
+            start: {
+                '@class': 'CdsPosition', offset: 0, pos: 123, prefix: 'c',
+            },
         }],
         ['c', '(123_456)_(567_890)del', {
             input: '(123_456)',
-            start: {'@class': 'CdsPosition', offset: 0, pos: 123, prefix: 'c'},
-            end: {'@class': 'CdsPosition', offset: 0, pos: 456, prefix: 'c'},
+            start: {
+                '@class': 'CdsPosition', offset: 0, pos: 123, prefix: 'c',
+            },
+            end: {
+                '@class': 'CdsPosition', offset: 0, pos: 456, prefix: 'c',
+            },
         }],
     ])('extracting positions for %s.%s', (prefix, string, expected) => {
         expect(extractPositions(prefix, string)).toEqual(expected);
@@ -117,7 +126,7 @@ describe('parseContinuous', () => {
         }],
         ['c.123_456del', {
             break1Start: {
-                '@class': 'CdsPosition', offset: 0, pos: 123, prefix: 'c', 
+                '@class': 'CdsPosition', offset: 0, pos: 123, prefix: 'c',
             },
             break1End: undefined,
             break2Start: {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -94,12 +94,17 @@ test.each([
 // reformatted notation
 test.each([
     ['FEATURE:p.Trp123*', 'FEATURE:p.W123*'], // * termination codon mixed with 3-letters AA
-    ['FEATURE:p.(L797P)', 'FEATURE:p.L797P'], // predicted protein consequence
     ['FEATURE:p.W288FS', 'FEATURE:p.W288fs'],
     ['FEATURE:p.R10Kfs*', 'FEATURE:p.R10Kfs'],
     ['FEATURE:p.Arg10Lysfs*10', 'FEATURE:p.R10Kfs*10'],
     ['FEATURE:p.Arg10_Lys12delArgGluLysinsLeu', 'FEATURE:p.R10_K12delREKinsL'],
     ['FEATURE:g.(1234_1237)_(1234_1237)dup2', 'FEATURE:g.(1234_1237)_(1234_1237)dup'], // useq size is irrelevant to dups
+    // KBDEV-1336/SDEV-5340; reformat predicted protein consequence
+    ['NBPF10:p.(L797P)', 'NBPF10:p.L797P'],
+    ['SHISA7:p.(A216_R218del)', 'SHISA7:p.A216_R218del'],
+    ['NP_001138648.1:p.(A216_R218del)', 'NP_001138648.1:p.A216_R218del'],
+    ['KRTAP4-7:p.(T68_C69delinsS)', 'KRTAP4-7:p.T68_C69delinsS'],
+    ['NP_149050.3:p.(T68_C69delinsS)', 'NP_149050.3:p.T68_C69delinsS'],
 ])('transforms from %s to %s', (notationIn, notationOut) => {
     const parsed = parseVariant(notationIn, true);
     expect(stringifyVariant(parsed)).toBe(notationOut);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,6 +7,7 @@ test.each([
     'KRAS:p.G12delG',
     'KRAS:p.G12_H14dupGHH',
     'EGFR:e.20_21ins',
+    'FEATURE:c.*123del',
     'FEATURE:c.-23+1A>G',
     'FEATURE:c.3+1del',
     'FEATURE:n.3+1del',
@@ -77,6 +78,7 @@ test.each([
 
 // notation without features
 test.each([
+    'c.*123del',
     'p.*807ext',
     'p.M1ext-85',
     'p.*807ext*101',
@@ -91,6 +93,7 @@ test.each([
 
 // reformatted notation
 test.each([
+    ['FEATURE:p.Trp123*', 'FEATURE:p.W123*'], // * termination codon mixed with 3-letters AA
     ['FEATURE:p.W288FS', 'FEATURE:p.W288fs'],
     ['FEATURE:p.R10Kfs*', 'FEATURE:p.R10Kfs'],
     ['FEATURE:p.Arg10Lysfs*10', 'FEATURE:p.R10Kfs*10'],
@@ -103,6 +106,7 @@ test.each([
 
 // reformatted notation without features
 test.each([
+    ['p.Trp123*', 'p.W123*'], // * termination codon mixed with 3-letters AA
     ['p.E55RfsTer11', 'p.E55Rfs*11'],
     ['p.*661Lext*?', 'p.*661Lext'],
     ['p.Arg80=', 'p.R80='],

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -105,6 +105,10 @@ test.each([
     ['NP_001138648.1:p.(A216_R218del)', 'NP_001138648.1:p.A216_R218del'],
     ['KRTAP4-7:p.(T68_C69delinsS)', 'KRTAP4-7:p.T68_C69delinsS'],
     ['NP_149050.3:p.(T68_C69delinsS)', 'NP_149050.3:p.T68_C69delinsS'],
+    // KBDEV-1336; 1-xxx assumed to mean -xxx
+    ['FEATURE:c.-234del', 'FEATURE:c.-234del'],
+    ['FEATURE:c.1-234del', 'FEATURE:c.-234del'],
+    ['FEATURE:r.1-234del', 'FEATURE:r.-234del'],
 ])('transforms from %s to %s', (notationIn, notationOut) => {
     const parsed = parseVariant(notationIn, true);
     expect(stringifyVariant(parsed)).toBe(notationOut);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,6 +9,9 @@ test.each([
     'EGFR:e.20_21ins',
     'FEATURE:c.*123del',
     'FEATURE:c.-23+1A>G',
+    'FEATURE:c.-234del',
+    'FEATURE:c.1-234del',
+    'FEATURE:r.1-234del',
     'FEATURE:c.3+1del',
     'FEATURE:n.3+1del',
     'FEATURE:c.3+1_5-2del',
@@ -99,16 +102,12 @@ test.each([
     ['FEATURE:p.Arg10Lysfs*10', 'FEATURE:p.R10Kfs*10'],
     ['FEATURE:p.Arg10_Lys12delArgGluLysinsLeu', 'FEATURE:p.R10_K12delREKinsL'],
     ['FEATURE:g.(1234_1237)_(1234_1237)dup2', 'FEATURE:g.(1234_1237)_(1234_1237)dup'], // useq size is irrelevant to dups
-    // KBDEV-1336/SDEV-5340; reformat predicted protein consequence
+    // KBDEV-1346/SDEV-5340; reformat predicted protein consequence
     ['NBPF10:p.(L797P)', 'NBPF10:p.L797P'],
     ['SHISA7:p.(A216_R218del)', 'SHISA7:p.A216_R218del'],
     ['NP_001138648.1:p.(A216_R218del)', 'NP_001138648.1:p.A216_R218del'],
     ['KRTAP4-7:p.(T68_C69delinsS)', 'KRTAP4-7:p.T68_C69delinsS'],
     ['NP_149050.3:p.(T68_C69delinsS)', 'NP_149050.3:p.T68_C69delinsS'],
-    // KBDEV-1336; 1-xxx assumed to mean -xxx
-    ['FEATURE:c.-234del', 'FEATURE:c.-234del'],
-    ['FEATURE:c.1-234del', 'FEATURE:c.-234del'],
-    ['FEATURE:r.1-234del', 'FEATURE:r.-234del'],
 ])('transforms from %s to %s', (notationIn, notationOut) => {
     const parsed = parseVariant(notationIn, true);
     expect(stringifyVariant(parsed)).toBe(notationOut);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -94,6 +94,7 @@ test.each([
 // reformatted notation
 test.each([
     ['FEATURE:p.Trp123*', 'FEATURE:p.W123*'], // * termination codon mixed with 3-letters AA
+    ['FEATURE:p.(L797P)', 'FEATURE:p.L797P'], // predicted protein consequence
     ['FEATURE:p.W288FS', 'FEATURE:p.W288fs'],
     ['FEATURE:p.R10Kfs*', 'FEATURE:p.R10Kfs'],
     ['FEATURE:p.Arg10Lysfs*10', 'FEATURE:p.R10Kfs*10'],

--- a/test/position.test.ts
+++ b/test/position.test.ts
@@ -8,13 +8,16 @@ import {
 
 describe('PATTERNS', () => {
     describe('PATTERNS.c', () => {
-        const pattern = PATTERNS['c'];
+        const pattern = PATTERNS.c;
+
         test.each([
             ['123G>A', '123'],
             ['*123G>A', '*123'],
         ])('match %s get %s', (string, expected) => {
             const match = new RegExp(`^(${pattern.source})`, 'i').exec(string);
-            const input = match ? match[0] : [];
+            const input = match
+                ? match[0]
+                : [];
             expect(input).toBe(expected);
         });
     });

--- a/test/position.test.ts
+++ b/test/position.test.ts
@@ -1,9 +1,24 @@
 import { ParsingError } from '../src/error';
 import {
+    PATTERNS,
     parsePosition,
     createPosition,
     convertPositionToString,
 } from '../src/position';
+
+describe('PATTERNS', () => {
+    describe('PATTERNS.c', () => {
+        const pattern = PATTERNS['c'];
+        test.each([
+            ['123G>A', '123'],
+            ['*123G>A', '*123'],
+        ])('match %s get %s', (string, expected) => {
+            const match = new RegExp(`^(${pattern.source})`, 'i').exec(string);
+            const input = match ? match[0] : [];
+            expect(input).toBe(expected);
+        });
+    });
+});
 
 describe('Position', () => {
     describe('CytobandPosition', () => {
@@ -79,6 +94,11 @@ describe('Position', () => {
             const pos = createPosition('c', { pos: null, offset: -10 });
             expect(convertPositionToString(pos)).toBe('?-10');
         });
+
+        test('3\' UTR offset', () => {
+            const pos = createPosition('c', { pos: 0, offset: 123 });
+            expect(convertPositionToString(pos)).toBe('*123');
+        });
     });
 
     describe('RnaPosition', () => {
@@ -151,6 +171,12 @@ describe('parsePosition', () => {
             expect(result.pos).toBe(1);
             expect(result.offset).toBe(0);
             expect(result).toHaveProperty('prefix', 'c');
+        });
+
+        test('3\' UTR offset', () => {
+            const result = parsePosition('c', '*123');
+            expect(result.pos).toBe(0);
+            expect(result.offset).toBe(123);
         });
 
         test('errors on spaces', () => {

--- a/test/position.test.ts
+++ b/test/position.test.ts
@@ -163,9 +163,16 @@ describe('parsePosition', () => {
         });
 
         test('negative offset', () => {
-            const result = parsePosition('c', '1-3');
-            expect(result.pos).toBe(1);
+            const result = parsePosition('c', '2-3');
+            expect(result.pos).toBe(2);
             expect(result.offset).toBe(-3);
+            expect(result).toHaveProperty('prefix', 'c');
+        });
+
+        test('negative position preceded by 1', () => {
+            const result = parsePosition('c', '1-3');
+            expect(result.pos).toBe(-3);
+            expect(result.offset).toBe(0);
             expect(result).toHaveProperty('prefix', 'c');
         });
 

--- a/test/position.test.ts
+++ b/test/position.test.ts
@@ -169,10 +169,10 @@ describe('parsePosition', () => {
             expect(result).toHaveProperty('prefix', 'c');
         });
 
-        test('negative position preceded by 1', () => {
+        test('negative offset preceded by 1', () => {
             const result = parsePosition('c', '1-3');
-            expect(result.pos).toBe(-3);
-            expect(result.offset).toBe(0);
+            expect(result.pos).toBe(1);
+            expect(result.offset).toBe(-3);
             expect(result).toHaveProperty('prefix', 'c');
         });
 

--- a/test/variant.test.ts
+++ b/test/variant.test.ts
@@ -131,6 +131,16 @@ describe('createVariantNotation', () => {
             });
         }).toThrowError('must be specified with a range');
     });
+
+    test('3\' UTR offset', () => {
+        const notation = createVariantNotation({
+            break1Start: createPosition('c', { pos: 0, offset: 123 }),
+            prefix: 'c',
+            reference1: { displayName: 'KRAS' },
+            type: NOTATION_TO_TYPES['del'],
+        });
+        expect(stringifyVariant(notation)).toBe('KRAS:c.*123del');
+    });
 });
 
 describe('stripParentheses', () => {

--- a/test/variant.test.ts
+++ b/test/variant.test.ts
@@ -137,7 +137,7 @@ describe('createVariantNotation', () => {
             break1Start: createPosition('c', { pos: 0, offset: 123 }),
             prefix: 'c',
             reference1: { displayName: 'KRAS' },
-            type: NOTATION_TO_TYPES['del'],
+            type: NOTATION_TO_TYPES.del,
         });
         expect(stringifyVariant(notation)).toBe('KRAS:c.*123del');
     });


### PR DESCRIPTION
This PR address:
- support for * as termination codon when mixed with 3-letters AAs. e.g. FEATURE:p.Trp123*
- support for * as termination codon position for 3'UTR variants. e.g. FEATURE:c.*123del
- correct parsing of 5'UTR positions. e.g. FEATURE:c.-123del
- <s>support of '1-' positions for backward compatibility.</s> Made sure '1-xxx' positions are interpreted as offset from the start codon. e.g. FEATURE:c.1-123del meaning offset of -123 from position 1.
- support of protein predicted consequences. e.g. FEATURE:p.(A123B)